### PR TITLE
CD 42-38ffc64d8361cfa164e71e4367a6347000663555 for golang-api-test

### DIFF
--- a/k8s/main/applications/golang-api-test.yaml
+++ b/k8s/main/applications/golang-api-test.yaml
@@ -16,7 +16,7 @@ spec:
     helm:
       parameters:
         - name: image.tag
-          value: "v0.0.41"
+          value: "v0.0.42"
       values: |-
         nameOverride: "golang-api-test"
         fullnameOverride: "golang-api-test"


### PR DESCRIPTION
Generated using CI/CD using workflow 42-38ffc64d8361cfa164e71e4367a6347000663555 for ArgoCD application golang-api-test